### PR TITLE
Implemented new LayerUnitTestStrategy

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
@@ -164,6 +164,7 @@ class GPTModel(MegatronModule):
         reduce_amax=True,
         use_emha=False,
         ub_tp_comm_overlap=False,
+        parallelization_specs=None,
     ):
         super(GPTModel, self).__init__(share_token_embeddings=share_embeddings_and_output_weights)
 
@@ -245,6 +246,7 @@ class GPTModel(MegatronModule):
             reduce_amax=reduce_amax,
             use_emha=use_emha,
             ub_tp_comm_overlap=ub_tp_comm_overlap,
+            parallelization_specs=parallelization_specs,
         )
 
         if self.share_embeddings_and_output_weights:

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -127,6 +127,7 @@ class MegatronBaseModel(NLPModel):
             init_mpi_proc_group=cfg.get('ub_tp_comm_overlap', False),
             seed=self.cfg.get('seed', 1234),
             apex_transformer_log_level=self.cfg.get('apex_transformer_log_level', 30),
+            parallelization_specs=self.cfg.get('parallelization_specs', None),
         )
 
         # This must be called after initialize model parallel since it needs to know the data parallel size

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -357,6 +357,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             reduce_amax=self.cfg.get('reduce_amax', True),
             use_emha=self.cfg.get('use_emha', False),
             ub_tp_comm_overlap=self.cfg.get('ub_tp_comm_overlap', False),
+            parallelization_specs=self.cfg.get('parallelization_specs', None),
         )
 
         return model

--- a/nemo/collections/nlp/modules/common/megatron/language_model.py
+++ b/nemo/collections/nlp/modules/common/megatron/language_model.py
@@ -117,6 +117,7 @@ def get_language_model(
     reduce_amax=True,
     use_emha=False,
     ub_tp_comm_overlap=False,
+    parallelization_specs=None,
 ):
     """Build language model and return along with the key to save."""
 
@@ -193,6 +194,7 @@ def get_language_model(
         reduce_amax=reduce_amax,
         use_emha=use_emha,
         ub_tp_comm_overlap=ub_tp_comm_overlap,
+        parallelization_specs=parallelization_specs,
     )
     # key used for checkpoints.
     language_model_key = 'language_model'
@@ -500,6 +502,7 @@ class TransformerLanguageModel(MegatronModule, adapter_mixins.AdapterModuleMixin
         reduce_amax=True,
         use_emha=False,
         ub_tp_comm_overlap=False,
+        parallelization_specs=None,
     ):
         super(TransformerLanguageModel, self).__init__(share_token_embeddings=share_embeddings_and_output_weights)
 
@@ -606,6 +609,7 @@ class TransformerLanguageModel(MegatronModule, adapter_mixins.AdapterModuleMixin
             reduce_amax=reduce_amax,
             use_emha=use_emha,
             ub_tp_comm_overlap=ub_tp_comm_overlap,
+            parallelization_specs=parallelization_specs,
         )
         self._encoder_key = 'encoder'
 
@@ -646,6 +650,7 @@ class TransformerLanguageModel(MegatronModule, adapter_mixins.AdapterModuleMixin
                 activations_checkpoint_granularity=activations_checkpoint_granularity,
                 activations_checkpoint_layers_per_pipeline=activations_checkpoint_layers_per_pipeline,
                 transformer_engine=transformer_engine,
+                parallelization_specs=parallelization_specs,
             )
             self._decoder_key = 'decoder'
 

--- a/nemo/collections/nlp/modules/common/megatron/new_init_playground.py
+++ b/nemo/collections/nlp/modules/common/megatron/new_init_playground.py
@@ -1,0 +1,168 @@
+def fake_initialize_model_parallel(
+    rank,
+    parallelization_specs,
+):
+    """
+    Fake initialize model data parallel groups so that we can instantiate model parallel models before DDP is initialized.
+    This is needed because PTL execution flow is init model, init trainer -> call trainer.fit(model). DDP is initialized during .fit.
+    This function is taken from megatron.core.parallel_state and modified so that the distributed groups are not created.
+    We only need the tensor parallel and pipeline parallel ranks to instantiate the model.
+
+    Arguments:
+        tensor_model_parallel_size: number of GPUs used to parallelize model tensor.
+        pipeline_model_parallel_size: number of GPUs used to parallelize model pipeline.
+
+    Let's say we have a total of 16 GPUs denoted by g0 ... g15 and we
+    use 2 GPUs to parallelize the model tensor, and 4 GPUs to parallelize
+    the model pipeline. The present function will
+    create 8 tensor model-parallel groups, 4 pipeline model-parallel groups
+    and 8 data-parallel groups as:
+        8 data_parallel groups:
+            [g0, g2], [g1, g3], [g4, g6], [g5, g7], [g8, g10], [g9, g11], [g12, g14], [g13, g15]
+        8 tensor model-parallel groups:
+            [g0, g1], [g2, g3], [g4, g5], [g6, g7], [g8, g9], [g10, g11], [g12, g13], [g14, g15]
+        4 pipeline model-parallel groups:
+            [g0, g4, g8, g12], [g1, g5, g9, g13], [g2, g6, g10, g14], [g3, g7, g11, g15]
+    Note that for efficiency, the caller should make sure adjacent ranks
+    are on the same DGX box. For example if we are using 2 DGX-1 boxes
+    with a total of 16 GPUs, rank 0 to 7 belong to the first box and
+    ranks 8 to 15 belong to the second box.
+    """
+
+    # Get world size and rank. Ensure some consistencies.
+    tensor_model_parallel_size = min(tensor_model_parallel_size_, world_size)
+    pipeline_model_parallel_size = min(pipeline_model_parallel_size_, world_size)
+    model_parallel_size = tensor_model_parallel_size * pipeline_model_parallel_size
+
+    assert (
+        world_size % tensor_model_parallel_size * pipeline_model_parallel_size == 0
+    ), f'world_size: {world_size} must be divisible by tensor_model_parallel_size: {tensor_model_parallel_size} times pipeline_model_parallel_size {pipeline_model_parallel_size}'
+    data_parallel_size = world_size // (tensor_model_parallel_size * pipeline_model_parallel_size)
+
+    num_tensor_model_parallel_groups = world_size // tensor_model_parallel_size
+    num_pipeline_model_parallel_groups = world_size // pipeline_model_parallel_size
+
+    virtual_pipeline_model_parallel_rank = None
+    if virtual_pipeline_model_parallel_size_ is not None:
+        virtual_pipeline_model_parallel_rank = 0
+
+    # Build the data-parallel groups.
+    all_data_parallel_group_ranks = []
+    for i in range(pipeline_model_parallel_size):
+        start_rank = i * num_pipeline_model_parallel_groups
+        end_rank = (i + 1) * num_pipeline_model_parallel_groups
+        for j in range(tensor_model_parallel_size):
+            ranks = range(start_rank + j, end_rank, tensor_model_parallel_size)
+            all_data_parallel_group_ranks.append(list(ranks))
+            if rank in ranks:
+                data_parallel_group = list(ranks)
+                logging.info(f'Rank {rank} has data parallel group: {data_parallel_group}')
+
+    data_parallel_rank = data_parallel_group.index(rank)
+    logging.info(f'All data parallel group ranks: {all_data_parallel_group_ranks}')
+    logging.info(f'Ranks {rank} has data parallel rank: {data_parallel_rank}')
+
+    # Build the model-parallel groups.
+    all_model_parallel_group_ranks = []
+    for i in range(data_parallel_size):
+        ranks = [data_parallel_group_ranks[i] for data_parallel_group_ranks in all_data_parallel_group_ranks]
+        all_model_parallel_group_ranks.append(ranks)
+        if rank in ranks:
+            logging.info(f'Rank {rank} has model parallel group: {list(ranks)}')
+    logging.info(f'All model parallel group ranks: {all_model_parallel_group_ranks}')
+
+    # Build the tensor model-parallel groups.
+    all_tensor_model_parallel_group_ranks = []
+    tensor_model_parallel_group = None
+    for i in range(num_tensor_model_parallel_groups):
+        ranks = range(i * tensor_model_parallel_size, (i + 1) * tensor_model_parallel_size)
+        all_tensor_model_parallel_group_ranks.append(list(ranks))
+        if rank in ranks:
+            tensor_model_parallel_group = list(ranks)
+            logging.info(f'Rank {rank} has tensor model parallel group: {tensor_model_parallel_group}')
+
+    tensor_model_parallel_rank = tensor_model_parallel_group.index(rank)
+
+    logging.info(f'All tensor model parallel group ranks: {all_tensor_model_parallel_group_ranks}')
+    logging.info(f'Rank {rank} has tensor model parallel rank: {tensor_model_parallel_rank}')
+
+    # Build the pipeline model-parallel groups and embedding groups
+    # (first and last rank in each pipeline model-parallel group).
+    all_pipeline_model_parallel_group_ranks = []
+    all_embedding_group_ranks = []
+    pipeline_model_parallel_group = None
+    embedding_group = None
+    embedding_rank = None
+    for i in range(num_pipeline_model_parallel_groups):
+        ranks = range(i, world_size, num_pipeline_model_parallel_groups)
+        all_pipeline_model_parallel_group_ranks.append(list(ranks))
+        if rank in ranks:
+            pipeline_model_parallel_group = list(ranks)
+            logging.info(f'Rank {rank} has pipeline model parallel group: {pipeline_model_parallel_group}')
+
+        # Setup embedding group (to exchange gradients between
+        # first and last stages).
+        if len(ranks) > 1:
+            embedding_ranks = [ranks[0], ranks[-1]]
+            all_embedding_group_ranks.append(embedding_ranks)
+        else:
+            embedding_ranks = ranks
+            all_embedding_group_ranks.append(list(embedding_ranks))
+        if rank in embedding_ranks:
+            embedding_group = list(embedding_ranks)
+            logging.info(f'Rank {rank} has embedding group: {embedding_group}')
+
+    pipeline_model_parallel_rank = pipeline_model_parallel_group.index(rank)
+    if embedding_group is not None:
+        embedding_rank = embedding_group.index(rank)
+
+    logging.info(f'All pipeline model parallel group ranks: {all_pipeline_model_parallel_group_ranks}')
+    logging.info(f'Rank {rank} has pipeline model parallel rank {pipeline_model_parallel_rank}')
+    logging.info(f'All embedding group ranks: {all_pipeline_model_parallel_group_ranks}')
+    logging.info(f'Rank {rank} has embedding rank: {embedding_rank}')
+
+    return (
+        tensor_model_parallel_rank,
+        pipeline_model_parallel_rank,
+        model_parallel_size,
+        data_parallel_size,
+        pipeline_model_parallel_split_rank_,
+        virtual_pipeline_model_parallel_rank,
+    )
+
+    
+if __name__ == '__main__':
+  parallelization_specs = {
+        "stimulus": {
+            "layers": [0,1,2,3,4,5],
+            "gpu_ranks": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],
+            "gpus_per_node": 8,
+            "data_parallel_group_size": 1,
+            "tensor_model_parallel_group_size": 8,
+            "pipeline_model_parallel_group_size": 2,
+            "micro_batch_size": 8
+        },
+        "test": {
+            "layers": [6],
+            "gpu_ranks": [16,17,18,19,20,21,22,23],
+            "gpus_per_node": 8,
+            "data_parallel_group_size": 1,
+            "tensor_model_parallel_group_size": 8,
+            "pipeline_model_parallel_group_size": 1,
+            "micro_batch_size": 8
+        },
+        "response": {
+            "layers": [7,8,9,10,11,12],
+            "gpu_ranks": [24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39],
+            "gpus_per_node": 8,
+            "data_parallel_group_size": 1,
+            "tensor_model_parallel_group_size": 8,
+            "pipeline_model_parallel_group_size": 2,
+            "micro_batch_size": 8
+        }
+  }
+  for i in range(0,40):
+    fake_initialize_model_components_parallel(
+        rank=i,
+        parallelization_specs=parallelization_specs,
+    )

--- a/nemo/collections/nlp/modules/common/megatron/offset_test.py
+++ b/nemo/collections/nlp/modules/common/megatron/offset_test.py
@@ -1,0 +1,57 @@
+def get_offset(parallelization_specs, pipeline_model_rank):
+    offset = 0
+    # pipeline_rank = parallel_state.get_pipeline_component_parallel_rank()
+    # pipeline_model_rank = 2
+    pipeline_model_rank_tracker = 0
+    component_tracker = 0
+    while pipeline_model_rank > pipeline_model_rank_tracker:
+        component_name = list(parallelization_specs.keys())[component_tracker]
+        component_num_layers = len(parallelization_specs[component_name]['layers'])
+        pipeline_component_parallel_group_size = parallelization_specs[component_name]['pipeline_model_parallel_group_size']
+        assert (
+                    component_num_layers % pipeline_component_parallel_group_size == 0
+                ), 'component_num_layers must be divisible by pipeline_component_parallel_group_size'
+        for pipeline_component_parallel_group_rank in range(pipeline_component_parallel_group_size):
+            if pipeline_model_rank_tracker < pipeline_model_rank:
+                offset += component_num_layers // pipeline_component_parallel_group_size
+            pipeline_model_rank_tracker += 1
+
+
+        component_tracker += 1
+
+    
+    print('offset: ' + str(offset))
+
+
+if __name__ == "__main__":
+    parallelization_specs = {
+        "stimulus": {
+            "layers": [0],
+            "gpu_ranks": [0,1,2,3,4,5,6,7],
+            "gpus_per_node": 1,
+            "data_parallel_group_size": 1,
+            "tensor_model_parallel_group_size": 8,
+            "pipeline_model_parallel_group_size": 1,
+            "micro_batch_size": 2
+        },
+        "test": {
+            "layers": [1],
+            "gpu_ranks": [8,9,10,11,12,13,14,15],
+            "gpus_per_node": 8,
+            "data_parallel_group_size": 1,
+            "tensor_model_parallel_group_size": 8,
+            "pipeline_model_parallel_group_size": 1,
+            "micro_batch_size": 2
+        },
+        "response": {
+            "layers": [2],
+            "gpu_ranks": [16,17,18,19,20,21,22,23],
+            "gpus_per_node": 8,
+            "data_parallel_group_size": 1,
+            "tensor_model_parallel_group_size": 8,
+            "pipeline_model_parallel_group_size": 1,
+            "micro_batch_size": 2
+        }
+    }
+    for i in range(3):
+        get_offset(parallelization_specs, i)

--- a/nemo/collections/nlp/modules/common/megatron/old_init_playground.py
+++ b/nemo/collections/nlp/modules/common/megatron/old_init_playground.py
@@ -1,0 +1,153 @@
+def fake_initialize_model_parallel(
+    world_size,
+    rank,
+    tensor_model_parallel_size_,
+    pipeline_model_parallel_size_,
+    pipeline_model_parallel_split_rank_=None,
+    virtual_pipeline_model_parallel_size_=None,
+):
+    # TODO TODO TODO(crankshaw): Update this
+    """
+    Fake initialize model data parallel groups so that we can instantiate model parallel models before DDP is initialized.
+    This is needed because PTL execution flow is init model, init trainer -> call trainer.fit(model). DDP is initialized during .fit.
+    This function is taken from megatron.core.parallel_state and modified so that the distributed groups are not created.
+    We only need the tensor parallel and pipeline parallel ranks to instantiate the model.
+
+    Arguments:
+        tensor_model_parallel_size: number of GPUs used to parallelize model tensor.
+        pipeline_model_parallel_size: number of GPUs used to parallelize model pipeline.
+
+    Let's say we have a total of 16 GPUs denoted by g0 ... g15 and we
+    use 2 GPUs to parallelize the model tensor, and 4 GPUs to parallelize
+    the model pipeline. The present function will
+    create 8 tensor model-parallel groups, 4 pipeline model-parallel groups
+    and 8 data-parallel groups as:
+        8 data_parallel groups:
+            [g0, g2], [g1, g3], [g4, g6], [g5, g7], [g8, g10], [g9, g11], [g12, g14], [g13, g15]
+        8 tensor model-parallel groups:
+            [g0, g1], [g2, g3], [g4, g5], [g6, g7], [g8, g9], [g10, g11], [g12, g13], [g14, g15]
+        4 pipeline model-parallel groups:
+            [g0, g4, g8, g12], [g1, g5, g9, g13], [g2, g6, g10, g14], [g3, g7, g11, g15]
+    Note that for efficiency, the caller should make sure adjacent ranks
+    are on the same DGX box. For example if we are using 2 DGX-1 boxes
+    with a total of 16 GPUs, rank 0 to 7 belong to the first box and
+    ranks 8 to 15 belong to the second box.
+    """
+
+    # Get world size and rank. Ensure some consistencies.
+    tensor_model_parallel_size = min(tensor_model_parallel_size_, world_size)
+    pipeline_model_parallel_size = min(pipeline_model_parallel_size_, world_size)
+    model_parallel_size = tensor_model_parallel_size * pipeline_model_parallel_size
+
+    assert (
+        world_size % tensor_model_parallel_size * pipeline_model_parallel_size == 0
+    ), f'world_size: {world_size} must be divisible by tensor_model_parallel_size: {tensor_model_parallel_size} times pipeline_model_parallel_size {pipeline_model_parallel_size}'
+    data_parallel_size = world_size // (tensor_model_parallel_size * pipeline_model_parallel_size)
+
+    num_tensor_model_parallel_groups = world_size // tensor_model_parallel_size
+    num_pipeline_model_parallel_groups = world_size // pipeline_model_parallel_size
+
+    virtual_pipeline_model_parallel_rank = None
+    if virtual_pipeline_model_parallel_size_ is not None:
+        virtual_pipeline_model_parallel_rank = 0
+
+    # Build the data-parallel groups.
+    all_data_parallel_group_ranks = []
+    for i in range(pipeline_model_parallel_size):
+        start_rank = i * num_pipeline_model_parallel_groups
+        end_rank = (i + 1) * num_pipeline_model_parallel_groups
+        for j in range(tensor_model_parallel_size):
+            ranks = range(start_rank + j, end_rank, tensor_model_parallel_size)
+            all_data_parallel_group_ranks.append(list(ranks))
+            if rank in ranks:
+                data_parallel_group = list(ranks)
+                print(f'Rank {rank} has data parallel group: {data_parallel_group}')
+
+    data_parallel_rank = data_parallel_group.index(rank)
+    print(f'All data parallel group ranks: {all_data_parallel_group_ranks}')
+    print(f'Ranks {rank} has data parallel rank: {data_parallel_rank}')
+
+    # Build the model-parallel groups.
+    all_model_parallel_group_ranks = []
+    for i in range(data_parallel_size):
+        ranks = [data_parallel_group_ranks[i] for data_parallel_group_ranks in all_data_parallel_group_ranks]
+        all_model_parallel_group_ranks.append(ranks)
+        if rank in ranks:
+            print(f'Rank {rank} has model parallel group: {list(ranks)}')
+    print(f'All model parallel group ranks: {all_model_parallel_group_ranks}')
+
+    # Build the tensor model-parallel groups.
+    all_tensor_model_parallel_group_ranks = []
+    tensor_model_parallel_group = None
+    for i in range(num_tensor_model_parallel_groups):
+        ranks = range(i * tensor_model_parallel_size, (i + 1) * tensor_model_parallel_size)
+        all_tensor_model_parallel_group_ranks.append(list(ranks))
+        if rank in ranks:
+            tensor_model_parallel_group = list(ranks)
+            print(f'Rank {rank} has tensor model parallel group: {tensor_model_parallel_group}')
+
+    tensor_model_parallel_rank = tensor_model_parallel_group.index(rank)
+
+    print(f'All tensor model parallel group ranks: {all_tensor_model_parallel_group_ranks}')
+    print(f'Rank {rank} has tensor model parallel rank: {tensor_model_parallel_rank}')
+
+    # Build the pipeline model-parallel groups and embedding groups
+    # (first and last rank in each pipeline model-parallel group).
+    all_pipeline_model_parallel_group_ranks = []
+    all_embedding_group_ranks = []
+    pipeline_model_parallel_group = None
+    embedding_group = None
+    embedding_rank = None
+    for i in range(num_pipeline_model_parallel_groups):
+        ranks = range(i, world_size, num_pipeline_model_parallel_groups)
+        all_pipeline_model_parallel_group_ranks.append(list(ranks))
+        if rank in ranks:
+            pipeline_model_parallel_group = list(ranks)
+            print(f'Rank {rank} has pipeline model parallel group: {pipeline_model_parallel_group}')
+
+        # Setup embedding group (to exchange gradients between
+        # first and last stages).
+        if len(ranks) > 1:
+            embedding_ranks = [ranks[0], ranks[-1]]
+            all_embedding_group_ranks.append(embedding_ranks)
+        else:
+            embedding_ranks = ranks
+            all_embedding_group_ranks.append(list(embedding_ranks))
+        if rank in embedding_ranks:
+            embedding_group = list(embedding_ranks)
+            print(f'Rank {rank} has embedding group: {embedding_group}')
+
+    pipeline_model_parallel_rank = pipeline_model_parallel_group.index(rank)
+    if embedding_group is not None:
+        embedding_rank = embedding_group.index(rank)
+
+    print(f'All pipeline model parallel group ranks: {all_pipeline_model_parallel_group_ranks}')
+    print(f'Rank {rank} has pipeline model parallel rank {pipeline_model_parallel_rank}')
+    print(f'All embedding group ranks: {all_pipeline_model_parallel_group_ranks}')
+    print(f'Rank {rank} has embedding rank: {embedding_rank}')
+
+    print(f'---RETURNED VALUES FOR RANK {rank}---')
+    print('tensor_model_parallel_rank: ' + str(tensor_model_parallel_rank))
+    print('pipeline_model_parallel_rank: ' + str(pipeline_model_parallel_rank))
+    print('model_parallel_size: ' + str(model_parallel_size))
+    print('data_parallel_size: ' + str(data_parallel_size))
+    print('pipeline_model_parallel_split_rank_: ' + str(pipeline_model_parallel_split_rank_))
+    print('virtual_pipeline_model_parallel_rank: ' + str(virtual_pipeline_model_parallel_rank))
+
+    return (
+        tensor_model_parallel_rank,
+        pipeline_model_parallel_rank,
+        model_parallel_size,
+        data_parallel_size,
+        pipeline_model_parallel_split_rank_,
+        virtual_pipeline_model_parallel_rank,
+    )
+    
+if __name__ == '__main__':
+    for rank in range(0,3):
+        fake_initialize_model_parallel(
+            world_size=3,
+            rank=rank,
+            tensor_model_parallel_size_=1,
+            pipeline_model_parallel_size_=3,
+        )

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -40,6 +40,7 @@ class AppState(metaclass=Singleton):
         self._global_rank = None
         self._tensor_model_parallel_rank = None
         self._pipeline_model_parallel_rank = None
+        self._pipeline_component_parallel_rank = None
         self._data_parallel_rank = None
 
         self._world_size = None
@@ -157,6 +158,22 @@ class AppState(metaclass=Singleton):
         self._pipeline_model_parallel_size = size
 
     @property
+    def pipeline_component_parallel_size(self):
+        """ Property returns the number of GPUs in each component parallel group.
+            Returns:
+                Number of GPUs in each component parallel group.
+        """
+        return self._pipeline_component_parallel_size
+
+    @pipeline_component_parallel_size.setter
+    def pipeline_component_parallel_size(self, size):
+        """ Property sets the number of GPUs in each component parallel group.
+            Args:
+                size (int):  Number of GPUs in each component parallel group.
+        """
+        self._pipeline_component_parallel_size = size
+
+    @property
     def virtual_pipeline_model_parallel_size(self):
         """ Property returns the number of GPUs in each model parallel group.
             Returns:
@@ -269,6 +286,22 @@ class AppState(metaclass=Singleton):
         self._pipeline_model_parallel_rank = rank
 
     @property
+    def pipeline_component_parallel_rank(self):
+        """ Property returns the pipeline component parallel rank.
+            Returns:
+                Pipeline component parallel rank.
+        """
+        return self._pipeline_component_parallel_rank
+
+    @pipeline_component_parallel_rank.setter
+    def pipeline_component_parallel_rank(self, rank):
+        """ Property sets the pipeline component parallel rank.
+            Args:
+                rank (int):  Pipeline component parallel rank.
+        """
+        self._pipeline_component_parallel_rank = rank
+
+    @property
     def virtual_pipeline_model_parallel_rank(self):
         """ Property returns the virtual pipeline parallel rank.
             Returns:
@@ -315,6 +348,22 @@ class AppState(metaclass=Singleton):
                 group:  Pipeline model parallel group.
         """
         self._pipeline_model_parallel_group = group
+
+    @property
+    def pipeline_component_parallel_group(self):
+        """ Property returns the pipeline component parallel group.
+            Returns:
+                Pipeline component parallel group.
+        """
+        return self._pipeline_component_parallel_group
+
+    @pipeline_component_parallel_group.setter
+    def pipeline_component_parallel_group(self, group):
+        """ Property sets the pipeline component parallel group.
+            Args:
+                group:  Pipeline component parallel group.
+        """
+        self._pipeline_component_parallel_group = group
 
     @property
     def data_parallel_rank(self):


### PR DESCRIPTION

# What does this PR do ?
This PR adds a new PTL strategy, `LayerUnitTestStrategy`. `LayerUnitTestStrategy` divides the model pipeline parallel groups into several segmented components, allowing for non-uniform pipeline parallelism.

More information on LayerUnitTestStrategy: http://shortn/_6frRXa7xdN

To use `LayerUnitTestStrategy`, add `parallelization_specs` to the configuration. 
Example:
```
parallelization_specs = {
    "stimulus": {
        "layers": [0,1,2,3,4,5],
        "gpu_ranks": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],
        "gpus_per_node": 8,
        "data_parallel_group_size": 1,
        "tensor_model_parallel_group_size": 8,
        "pipeline_model_parallel_group_size": 2,
        "micro_batch_size": 2,
    },
    "test": {
        "layers": [6],
        "gpu_ranks": [16,17,18,19,20,21,22,23],
        "gpus_per_node": 8,
        "data_parallel_group_size": 1,
        "tensor_model_parallel_group_size": 8,
        "pipeline_model_parallel_group_size": 1,
        "micro_batch_size": 2,
    },
    "response": {
        "layers": [7,8,9,10,11,12],
        "gpu_ranks": [24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39],
        "gpus_per_node": 8,
        "data_parallel_group_size": 1,
        "tensor_model_parallel_group_size": 8,
        "pipeline_model_parallel_group_size": 2,
        "micro_batch_size": 2,
    }
}
```
Removed other portions of PR template since this is for a fork
