### PR TITLE
remove gcsfuse from nemo deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=us-central1-docker.pkg.dev/supercomputer-testing/redrock-dev/nemo-deps:20230828-004520
+ARG BASE_IMAGE=us-central1-docker.pkg.dev/supercomputer-testing/redrock-dev/nemo-deps:20231011-205139
 
 # build an image that includes only the nemo dependencies, ensures that dependencies
 # are included first for optimal caching, and useful for building a development

--- a/NemoDeps.Dockerfile
+++ b/NemoDeps.Dockerfile
@@ -34,22 +34,6 @@ RUN apt-get update && \
   libavdevice-dev && \
   rm -rf /var/lib/apt/lists/*
 
-# GCSfuse components
-RUN apt-get update && apt-get install --yes --no-install-recommends \
-    ca-certificates \
-    curl \
-    gnupg \
-  && echo "deb http://packages.cloud.google.com/apt gcsfuse-focal main" \
-    | tee /etc/apt/sources.list.d/gcsfuse.list \
-  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-  && apt-get update \
-  && apt-get install --yes gcsfuse \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && mkdir -p /gcs/training-data && mkdir -p /gcs/checkpoints
-
-# NFS components (needed if using PD-SSD for shared file-system)
-RUN apt-get -y update && apt-get install -y nfs-common
-
 WORKDIR /workspace/
 
 WORKDIR /tmp/


### PR DESCRIPTION
Updates the base docker image used in `Dockerfile` and removes gcsfuse dependency in NemoDeps.Dockerfile